### PR TITLE
create: edit

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -73,7 +73,8 @@ class PostsController extends Controller
      */
     public function edit($id)
     {
-        //
+        $post = Post::findOrFail($id);
+        return view('posts.edit', ['post' => $post,]);
     }
 
     /**

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,34 @@
+@extends('layouts.app')
+
+@section('content')
+
+
+    <div class="container create_form">
+        <h4>投稿の編集</h4>
+        @if ($errors->any())
+            <div class="alert alert-danger">
+                <ul>
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
+        {!! Form::open(['route' => 'store']) !!}
+
+            <div class="form-group">
+                {!! Form::label('title', 'タイトル') !!}
+                {!! Form::text('title', null, ['class' => 'form-control']) !!}
+            </div>
+            <div class="form-group">
+                {!! Form::label('body', '本文') !!}
+                {!! Form::textarea('body', null, ['class' => 'form-control', 'row' => '5']) !!}
+            </div>
+
+            {!! link_to_route('top', 'キャンセル', [], ['class' => 'btn btn-secondary']) !!}
+            {!! Form::submit('更新する', ['class' => 'btn btn-primary']) !!}
+
+        {!! Form::close() !!}
+    </div>
+@endsection

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
 <div class="container text-right mt-3 mb-2">
-    <button type="button" class="btn btn-primary p-1">編集する</button>
+    <a href="{{ url('posts/'.$post->id.'/edit') }}" class="btn btn-primary p-1">編集する</a>
     <button type="button" class="btn btn-danger p-1">削除する</button>
 </div>
 

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
 <div class="container text-right mt-3 mb-2">
-    <a href="{{ url('posts/'.$post->id.'/edit') }}" class="btn btn-primary p-1">編集する</a>
+    <a href="{{ route('edit', ['id' => $post]) }}" class="btn btn-primary p-1">編集する</a>
     <button type="button" class="btn btn-danger p-1">削除する</button>
 </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,3 +23,6 @@ Route::post('posts', 'PostsController@store')->name('store');
 
 // 詳細画面一覧
 Route::get('posts/{id}', 'PostsController@show')->name('show');
+
+// 編集画面
+Route::get('posts/{id}/edit', 'PostsController@edit')->name('edit');


### PR DESCRIPTION
編集画面の表示をできるようにしました。

画面表示は新規投稿画面をコピーしてきたのでformのルーティングはstoreのままになっています。
バリデーションもそのままなので今回新たに設定はしていません！

今回
詳細ページの「編集する」ボタンから編集画面のページに飛ばすリンクを
route('edit')とするとエラーがでたため
url('posts/'.$post->id.'/edit')と記述したのですが、
なぜroute('edit')とするとエラーが出るかがわかりませんでした。
エラー表示は
Missing required parameters for [Route: edit] [URI: posts/{id}/edit].
と出ていました。

ご確認よろしくお願いします。
![スクリーンショット (23)](https://user-images.githubusercontent.com/79707482/111895429-da0bed00-8a55-11eb-8ec7-27eb11f0d760.png)
![スクリーンショット (24)](https://user-images.githubusercontent.com/79707482/111895460-01fb5080-8a56-11eb-862e-f53d087f2233.png)
