### PR TITLE
共同開発：コメント削除機能

### DIFF
--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -30,7 +30,7 @@ class CommentsController extends Controller
 
     public function edit($comment_id)
     {
-        $comment = Comment::findOrFail($comment_id)->first();
+        $comment = Comment::findOrFail($comment_id);
 
         return view('comments.comment_edit', ['comment' => $comment]);
     }
@@ -44,6 +44,14 @@ class CommentsController extends Controller
 
         $comment = Comment::findOrFail($comment_id);
         $comment->fill($params)->save();
+
+        return redirect('/');
+    }
+
+    public function destroy($comment_id)
+    {
+        $comment = Comment::findOrFail($comment_id);
+        $comment->delete();
 
         return redirect('/');
     }

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -50,8 +50,7 @@ class CommentsController extends Controller
 
     public function destroy($comment_id)
     {
-        $comment = Comment::findOrFail($comment_id);
-        $comment->delete();
+        $comment = Comment::findOrFail($comment_id)->delete();
 
         return redirect('/');
     }

--- a/resources/views/comments/comment_edit.blade.php
+++ b/resources/views/comments/comment_edit.blade.php
@@ -10,6 +10,9 @@
           <h5 class="mb-2">コメントの編集</h5>
         </div>
         <div class="card-body">
+          {!! Form::open(['route' => ['comment.delete', $comment->id], 'method' => 'delete']) !!}
+          {!! Form::submit('削除する', ['class' => 'btn btn-danger w-25']) !!}
+          {!! Form::close() !!}
           <div class="md-form">
             {!! Form::open(['route' => ['comment.update', $comment->id], "accept-charset" => "UTF-8", 'method' => 'put']) !!}
             {{csrf_field()}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,9 @@ Route::post('/comment', 'CommentsController@store')->name('comment.store');
 Route::get('/comment/{comment_id}', 'CommentsController@edit')->name('comment.edit');
 Route::put('/comment_edit/{comment_id}', 'CommentsController@update')->name('comment.update');
 
+// コメント削除
+Route::delete('/comment/{comment_id}', 'CommentsController@destroy')->name('comment.delete');
+
 // 投稿編集画面
 Route::get('posts/{id}/edit', 'PostsController@edit')->name('edit');
 Route::post('posts/{id}', 'PostsController@update')->name('update');


### PR DESCRIPTION
コメントの削除を実装しました。
一覧画面での削除の実装ができなかったため
コメント編集画面で削除ができるようにしました。

CommentsControllerにdestroy関数を追加しました。

削除の実装の際に
CommentsController内のedit関数内が
$comment = Comment::findOrFail($comment_id)->first();
となっていたのですが
->first()があるとコメント削除の箇所がズレる現象があったので削除しました。

ご確認よろしくお願いします。