### PR TITLE
ユーザ更新画面作成。 #78

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\UserUpdateRequest;
 use Illuminate\Http\Request;
 use App\User;
 
@@ -16,5 +17,36 @@ class UsersController extends Controller
     public function show(User $user)
     {
         return view('users.show', ['user' => $user]);
+    }
+
+    /**
+     * ユーザー更新画面
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function edit()
+    {
+        return view('users.edit');
+    }
+
+    /**
+     * ユーザー更新処理
+     *
+     * @param App\Http\Requests\UserUpdateRequest $request
+     * @param App\User $user
+     */
+    public function update(UserUpdateRequest $request, User $user)
+    {
+        $user = User::find($request->id);
+
+        if ($request->email == $user->email) {
+            // メールアドレスの変更なし
+            $user->fill($request->except('email'))->save();
+        } else {
+            // メールアドレスの変更あり
+            $user->fill($request->all())->save();
+        }
+
+        return redirect()->route('users.show', ['user' => $user]);
     }
 }

--- a/app/Http/Requests/UserUpdateRequest.php
+++ b/app/Http/Requests/UserUpdateRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UserUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users')->ignore($this->id)],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ];
+    }
+}

--- a/public/css/application.css
+++ b/public/css/application.css
@@ -1,0 +1,15 @@
+body {
+    background-color: #fafafa;
+    font-size: 14px;
+    color: #262626;
+}
+
+.edit-profile-wrapper {
+    margin-top: 60px;
+}
+
+.profile-form-wrap {
+    background-color: #fff;
+    padding: 20px;
+    border: 1px solid #e6e6e6;
+}

--- a/resources/views/common/header.blade.php
+++ b/resources/views/common/header.blade.php
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand navbar-light ">
-    <a class="navbar-brand" href=""><i class="fas fa-home fa-2x"></i>
+    <a class="navbar-brand" href="/"><i class="fas fa-home fa-2x"></i>
     </a>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav ml-md-auto align-items-center">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,7 +19,9 @@
                 <link href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" rel="stylesheet">
     </head>
     <body>
-        @include('common.header')
+        @unless(Request::is(['login','signup']))
+            @include('common.header')
+        @endunless
 
         @yield('content')
 

--- a/resources/views/layouts/user_update_error_card_list.blade.php
+++ b/resources/views/layouts/user_update_error_card_list.blade.php
@@ -1,0 +1,10 @@
+@if (count($errors) > 0)
+    <div class="alert alert-danger">
+        <strong>入力した文字を修正してください。</strong>
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -4,7 +4,7 @@
     <div class="col-md-offset-2 mb-1 edit-profile-wrapper">
         <div class="row">
             <div class="col-md-8 mx-auto">
-                @include('layouts.error_card_list')
+                @include('layouts.user_update_error_card_list')
                 <div class="profile-form-wrap">
                     <form class="edit_user" enctype="multipart/form-data" action="{{ route('users.update') }}" accept-charset="UTF-8" method="post">
                         <input name="utf8" type="hidden" value="&#x2713;" />

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('content')
-    <div class="col-md-offset-2 mb-1 edit-profile-wrapper my-5 ">
+    <div class="col-md-offset-2 mb-1 edit-profile-wrapper">
         <div class="row">
             <div class="col-md-8 mx-auto">
                 @include('layouts.error_card_list')

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="col-md-offset-2 mb-1 edit-profile-wrapper my-5 ">
+        <div class="row">
+            <div class="col-md-8 mx-auto">
+                @include('layouts.error_card_list')
+                <div class="profile-form-wrap">
+                    <form class="edit_user" enctype="multipart/form-data" action="{{ route('users.update') }}" accept-charset="UTF-8" method="post">
+                        <input name="utf8" type="hidden" value="&#x2713;" />
+                        <input type="hidden" name="id" value="{{ Auth::id() }}" />
+                        {{ csrf_field() }}
+                        @method('put')
+                        <div class="form-group">
+                            <label for="name">ユーザー名</label>
+                            <input autofocus="autofocus" class="form-control" value="{{ old('name') ?? Auth::user()->name }}" name="name" />
+                        </div>
+
+                        <div class="form-group">
+                            <label for="email">メールアドレス</label>
+                            <input autofocus="autofocus" class="form-control" value="{{ old('email') ?? Auth::user()->email }}" name="email" />
+                        </div>
+
+                        <div class="form-group">
+                            <label for="password">パスワード</label>
+                            <input autofocus="autofocus" class="form-control" type="password" name="password" />
+                        </div>
+
+                        <div class="form-group">
+                            <label for="password_confirmation">パスワードの確認</label>
+                            <input autofocus="autofocus" class="form-control" type="password" name="password_confirmation" />
+                        </div>
+
+                        <div class="text-center">
+                            <input type="submit" name="commit" value="変更する" class="btn btn-primary" data-disable-with="変更する" />
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -14,7 +14,7 @@
 
                     @if( Auth::id() == $user->id )
                         <div class="col-12 mt-3">
-                            <a class="btn btn-outline-dark common-btn btn-sm edit-profile-btn" href="/users/edit"><i class="fas fa-user-edit"></i>プロフィール編集
+                            <a class="btn btn-outline-dark common-btn btn-sm edit-profile-btn" href="{{ route('users.edit') }}"><i class="fas fa-user-edit"></i>プロフィール編集
                             </a>
                             <a class="btn btn-outline-dark common-btn btn-sm edit-profile-btn" rel="nofollow" data-method="POST" href="{{ route('logout') }}"><i class="fas fa-cog"></i>ログアウト
                             </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,5 +22,7 @@ Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('sign
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
 Route::prefix('users')->group(function () {
+    Route::get('/edit', 'UsersController@edit')->name('users.edit');
     Route::get('/{user}', 'UsersController@show')->name('users.show');
+    Route::put('/', 'UsersController@update')->name('users.update');
 });


### PR DESCRIPTION
お疲れ様です。

やったこと
- `UsersController`に更新画面、更新処理メソッドを追加。
- 更新画面の実装
- 詳細画面から更新画面へのリンクを設定
- 更新画面と更新処理へのルーティングを追加。
- ログイン、新規登録画面の場合ヘッダーを非表示にするように修正。
- バリデーションエラーメッセージ表示ファイルを追加。

考慮して欲しいこと
- 自分自身のemailアドレスの場合は`unique`バリデーションに弾かれないように修正しました。
- 更新処理`update`にて、自分自身のメールアドレスかどうかを検証し分岐して更新するように修正しました。
- 更新処理時のバリデーションメッセージの表示方法が異なっていたので別途用意して対応するようにいたしました。

更新処理の記述方法に関して、もっと良い方法等があればぜひ教えていただきたいです。
ご確認のほどよろしくお願いします。