### PR TITLE
コメントテーブルのマイグレーションとシーダー作成。 #72

### DIFF
--- a/app/Comment.php
+++ b/app/Comment.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    protected $fillable = [
+        'comment',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/database/migrations/2021_05_05_013629_create_posts_table.php
+++ b/database/migrations/2021_05_05_013629_create_posts_table.php
@@ -14,7 +14,7 @@ class CreatePostsTable extends Migration
     public function up()
     {
         Schema::create('posts', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->bigInteger('user_id')->unsigned()->index();
             $table->string('title', 50);
             $table->text('message');

--- a/database/migrations/2021_05_11_203711_create_comments_table.php
+++ b/database/migrations/2021_05_11_203711_create_comments_table.php
@@ -19,7 +19,7 @@ class CreateCommentsTable extends Migration
             $table->bigInteger('post_id')->unsigned();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
-            $table->string('comment', 60);
+            $table->string('comment');
             $table->timestamps();
         });
     }

--- a/database/migrations/2021_05_11_203711_create_comments_table.php
+++ b/database/migrations/2021_05_11_203711_create_comments_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned();
+            $table->bigInteger('post_id')->unsigned();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $table->string('comment', 60);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comments');
+    }
+}

--- a/database/seeds/CommentsTableSeeder.php
+++ b/database/seeds/CommentsTableSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class CommentsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('comments')->insert([
+            [
+                'user_id' => rand(0, 9),
+                'post_id' => 1,
+                'comment' => "コメント1",
+                'created_at' => date('Y-m-d H:i:s'),
+                'updated_at' => date('Y-m-d H:i:s'),
+            ],
+            [
+                'user_id' => rand(0, 9),
+                'post_id' => 2,
+                'comment' => "コメント2",
+                'created_at' => date('Y-m-d H:i:s'),
+                'updated_at' => date('Y-m-d H:i:s'),
+            ],
+            [
+                'user_id' => rand(0, 9),
+                'post_id' => 3,
+                'comment' => "コメント3",
+                'created_at' => date('Y-m-d H:i:s'),
+                'updated_at' => date('Y-m-d H:i:s'),
+            ],
+        ]);
+    }
+}

--- a/database/seeds/CommentsTableSeeder.php
+++ b/database/seeds/CommentsTableSeeder.php
@@ -11,28 +11,30 @@ class CommentsTableSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('comments')->insert([
-            [
-                'user_id' => rand(0, 9),
-                'post_id' => 1,
-                'comment' => "コメント1",
-                'created_at' => date('Y-m-d H:i:s'),
-                'updated_at' => date('Y-m-d H:i:s'),
-            ],
-            [
-                'user_id' => rand(0, 9),
-                'post_id' => 2,
-                'comment' => "コメント2",
-                'created_at' => date('Y-m-d H:i:s'),
-                'updated_at' => date('Y-m-d H:i:s'),
-            ],
-            [
-                'user_id' => rand(0, 9),
-                'post_id' => 3,
-                'comment' => "コメント3",
-                'created_at' => date('Y-m-d H:i:s'),
-                'updated_at' => date('Y-m-d H:i:s'),
-            ],
-        ]);
+        for ($i = 1; $i <= 5; $i++) {
+            DB::table('comments')->insert([
+                [
+                    'user_id' => rand(1, 10),
+                    'post_id' => rand(1, 3),
+                    'comment' => "コメント{$i}-1",
+                    'created_at' => date('Y-m-d H:i:s'),
+                    'updated_at' => date('Y-m-d H:i:s'),
+                ],
+                [
+                    'user_id' => rand(1, 10),
+                    'post_id' => rand(1, 3),
+                    'comment' => "コメント{$i}-2",
+                    'created_at' => date('Y-m-d H:i:s'),
+                    'updated_at' => date('Y-m-d H:i:s'),
+                ],
+                [
+                    'user_id' => rand(1, 10),
+                    'post_id' => rand(1, 3),
+                    'comment' => "コメント{$i}-3",
+                    'created_at' => date('Y-m-d H:i:s'),
+                    'updated_at' => date('Y-m-d H:i:s'),
+                ],
+            ]);
+        }
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -13,5 +13,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(UsersTableSeeder::class);
         $this->call(PostsTableSeeder::class);
+        $this->call(CommentsTableSeeder::class);
     }
 }


### PR DESCRIPTION
お疲れ様です。

やったこと
- コメントマイグレーションファイル作成。
- コメントモデルファイル作成。
- コメントシーダー作成。
- postsマイグレーションファイルのidを`bigInteger`に修正。

考慮して欲しいこと
- `CommentsTableSeeder`において`user_id`はランダムで設定するようにしました。
- `factory`を利用してシーダーファイルを作成しようか考えましたが、Postsシーダーファイルも修正する必要があると感じたため、`factory`を利用した実装は投稿機能が実装してから、なおやさんと共有して実装しようかと考えていました。

ご確認のほどお願いします。