### PR TITLE
編集時ミドルウェア追加

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -56,10 +56,6 @@ class PostsController extends Controller
     public function edit($id)
     {
         $post = Post::findOrFail($id);
-
-        if (auth()->user()->id != $post->user_id) {
-            return redirect('/')->with('error', '許可されていない操作です');
-        }
         
         return view('post.edit', ['post' => $post]);
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -52,6 +52,7 @@ class Kernel extends HttpKernel
      */
     protected $routeMiddleware = [
         'auth' => \App\Http\Middleware\Authenticate::class,
+        'editcheck' => \App\Http\Middleware\EditCheck::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,

--- a/app/Http/Middleware/EditCheck.php
+++ b/app/Http/Middleware/EditCheck.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use App\Post;
+
+class EditCheck
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $param = $request->route()->parameter('id');
+
+        $post = Post::findOrFail($param);
+
+        if (auth()->user()->id !== $post->user_id) {
+            return redirect('/')->with('error', '許可されていない操作です');
+        }
+        return $next($request);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/', 'PostsController@index');
     Route::get('posts/new', 'PostsController@create')->name('posts.create');
     Route::post('posts', 'PostsController@store')->name('posts.store');
-    Route::get('post/{id}/edit', 'PostsController@edit')->name('post.edit');
+    Route::get('post/{id}/edit', 'PostsController@edit')->name('post.edit')->middleware('editcheck');
     Route::post('post/{id}', 'PostsController@update')->name('post.update');
 
 });


### PR DESCRIPTION
https://github.com/quest-academia/laravel-posts-training/pull/141　の際に指摘頂いた件。
PostsControllerに「他のユーザーが変更できないよう」にする処理を書くのではなく、
ルーティングの際にミドルウエアでAuthチェックした方がいいと言うことを指摘頂きました。

その件に関してkouさんと相談し、自分たちなりに解決したのでプルリクを出しました。

確認のほどよろしくお願いします。