### PR TITLE
#170 投稿編集画面の作成　小野

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\PostsUpdateRequest;
 use App\Post;
 use Illuminate\Http\Request;
 
@@ -62,7 +63,18 @@ class PostsController extends Controller
      */
     public function edit($id)
     {
-        //
+        $post = Post::findOrFail($id);
+
+        // 投稿者以外の編集を規制
+        if (auth()->user()->id != $post->user_id) {
+            return redirect('/');
+        }
+
+        //更新画面へ
+        return view('posts.edit', [
+            'post' => $post,
+        ]);
+
     }
 
     /**
@@ -72,9 +84,22 @@ class PostsController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(PostsUpdateRequest $request, $id)
     {
-        //
+        // idで受け取ったものを更新する
+        $post = Post::findOrFail($id);
+
+        // 投稿者以外の編集を規制
+        if (auth()->user()->id != $post->user_id) {
+            return redirect('/');
+        }
+
+        $post->title = $request->input('title');
+        $post->body = $request->input('body');
+        $post->save();
+
+        return redirect('/');
+
     }
 
     /**

--- a/app/Http/Requests/PostsUpdateRequest.php
+++ b/app/Http/Requests/PostsUpdateRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostsUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|max:50',
+            'body' => 'required',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            "title.required" => "タイトルは必ず指定してください",
+            "title.max" => "コメントは50文字以下で入力して下さい",
+            "body.required" => "本文は必ず入力してください",
+
+        ];
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -60,8 +60,9 @@
                                 </a>
 
                                 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-                                    <a class="dropdown-item" href="{{ route('logout') }}" onclick="event.preventDefault();
-                                                                         document.getElementById('logout-form').submit();">
+                                    <a class="dropdown-item" href="{{ route('logout') }}"
+                                        onclick="event.preventDefault();
+                                                                                 document.getElementById('logout-form').submit();">
                                         {{ __('Logout') }}
                                     </a>
 
@@ -81,7 +82,7 @@
 
     <div class="container">
 
-        @include('commons.error_messages')
+        {{-- @include('commons.error_messages') --}}
 
         @yield('content')
 

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -10,14 +10,16 @@
                         投稿の編集
                     </div>
                     <div class="card-body">
-                        <form class="upload" id="new_post" enctype="multipart/form-data" action="" accept-charset="UTF-8"
-                            method="POST">
+                        <form class="upload" id="new_post" enctype="multipart/form-data" action="/posts/{{ $post->id }}"
+                            accept-charset="UTF-8" method="POST">
                             {{ csrf_field() }}
                             <div class="md-form">
-                                <input class="form-control" placeholder="タイトル" type="text" name="title" value="" />
+                                <input class="form-control" placeholder="タイトル" type="text" name="title"
+                                    value="{{ old('title') ?? $post->title }}" />
                             </div>
                             <div class="form-group">
-                                <textarea name="body" class="form-control" rows="10" placeholder="本文"></textarea>
+                                <textarea name="body" class="form-control" rows="10"
+                                    placeholder="本文">{{ old('body') ?? $post->body }}</textarea>
                             </div>
                             <div class="text-center">
                                 <input type="submit" name="commit" value="更新する" class="btn btn-primary w-25"

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -27,7 +27,8 @@
                     <div class="card-body">
                         <div class="post_edit text-right">
                             @if (Auth::id() == $post->user_id)
-                                <a class="btn btn-primary btn-sm" href=""><i class="far fa-edit"></i>編集
+                                <a class="btn btn-primary btn-sm" href="/posts/{{ $post->id }}/edit"><i
+                                        class="far fa-edit"></i>編集
                                 </a>
                                 <a class="btn btn-danger btn-sm" rel="nofollow" href=""><i class="far fa-trash-alt"></i>削除
                                 </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,7 +19,8 @@ Route::group(['middleware' => 'auth'], function () {
     // 投稿一覧ページへ
     Route::get('/', 'PostsController@index');
     // 重複を避けるためのexcept
-    Route::resource('posts', 'PostsController', ['except' => ['index', 'destroy']]);
+    Route::resource('posts', 'PostsController', ['except' => ['index', 'update', 'destroy']]);
+    Route::post('posts/{post}', 'PostsController@update');
     Route::delete('posts/{id}', 'PostsController@destory')->name('posts.destroy');
 
     Route::post('/comments/store', 'CommentsController@store')->name('comments.store');


### PR DESCRIPTION
✅やったこと
投稿編集画面の作成をしました。

✅編集したこと
・index.blade.php 
編集ボタンをクリックすると投稿編集画面に遷移する指定しました。

・edit.blade.php
投稿編集画面。編集前の値を取得し入力された後更新ボタンを押すと
PostsControllerのupdate アクションを呼ぶルーティングを指定しました。

・web.php
update アクションのルーティングを別で記載しました。

・PostsUpdateRequest.php
投稿編集の画面のバリデーションを記載しました。

・PostsController
editアクションはviewへの画面遷移を記載、
updateアクションにはviewから受け取った値に更新し
トップページへリダイレクトする記述をしました。

✅バリデーションの有無
バリデーション有り

✅考慮して欲しいこと
須賀さんとの情報共有で教えていただいたのですがログインユーザ以外がURLの直入力で
投稿を編集できない記述をコントローラーに記述しています。
そちらもご確認お願いいたします。


