### PR TITLE
CommentsMigrationファイルへ外部キー制約の追加(脇田)

### DIFF
--- a/database/migrations/2021_08_05_222556_create_comments_table.php
+++ b/database/migrations/2021_08_05_222556_create_comments_table.php
@@ -15,7 +15,7 @@ class CreateCommentsTable extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->integer('post_id')->unsigned()->nullable(false);
+            $table->biginteger('post_id')->unsigned()->nullable(false);
             $table->biginteger('user_id')->unsigned()->nullable(false);
             $table->string('content')->nullable(false);
             $table->timestamps();

--- a/database/migrations/2021_08_05_222556_create_comments_table.php
+++ b/database/migrations/2021_08_05_222556_create_comments_table.php
@@ -15,10 +15,13 @@ class CreateCommentsTable extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->integer('post_id')->nullable(false);
-            $table->integer('user_id')->nullable(false);
+            $table->integer('post_id')->unsigned()->nullable(false);
+            $table->biginteger('user_id')->unsigned()->nullable(false);
             $table->string('content')->nullable(false);
             $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            // $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
         });
     }
 


### PR DESCRIPTION
# やったこと(what)
- 外部キー制約を追加

# 編集した箇所
user_id,post_idを以下の通り修正
- unsigned()を追加
- bigintegerに変更

# 変更の背景
Usersテーブル、Postsテーブルのid の型がbigIncrementsになっており、Commentsテーブルのuser_id、post_idの型がintegerになっておりました。

foreign_keyとして設定する場合、型の不一致があるとエラーとなるので、その点を修正しました。

# 補足
　- postsテーブルが追加された後、外部キー制約を追加するためpostsテーブルの外部キー制約はコメントアウトしています。